### PR TITLE
Improve error handling & use async get_size

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 dist
+.idea

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -190,6 +190,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
 
 [[package]]
+name = "byte-unit"
+version = "4.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da78b32057b8fdfc352504708feeba7216dcd65a2c9ab02978cbd288d1279b6c"
+dependencies = [
+ "serde",
+ "utf8-width",
+]
+
+[[package]]
 name = "bytemuck"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -707,6 +717,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fern"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9f0c14694cbd524c8720dd69b0e3179344f04ebb5f90f2e4a440c6ea3b2f1ee"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "field-offset"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1085,6 +1104,17 @@ dependencies = [
  "fnv",
  "log",
  "regex",
+]
+
+[[package]]
+name = "globwalk"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93e3af942408868f6934a7b85134a3230832b9977cf66125df2f9edcfce4ddcc"
+dependencies = [
+ "bitflags 1.3.2",
+ "ignore",
+ "walkdir",
 ]
 
 [[package]]
@@ -1499,6 +1529,9 @@ name = "log"
 version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+dependencies = [
+ "value-bag",
+]
 
 [[package]]
 name = "loom"
@@ -1561,9 +1594,9 @@ checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
 name = "memchr"
-version = "2.5.0"
+version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+checksum = "8f232d6ef707e1956a43342693d2a31e72989554d58299d7a88738cc95b0d35c"
 
 [[package]]
 name = "memoffset"
@@ -1634,13 +1667,16 @@ name = "nmw"
 version = "0.0.0"
 dependencies = [
  "fs_extra",
- "glob",
+ "globwalk",
+ "log",
  "rayon",
+ "regex",
  "serde",
  "serde_json",
  "specta",
  "tauri",
  "tauri-build",
+ "tauri-plugin-log",
  "tauri-specta",
  "thiserror",
  "tokio",
@@ -1724,6 +1760,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_threads"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "objc"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1731,6 +1776,17 @@ checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
 dependencies = [
  "malloc_buf",
  "objc_exception",
+]
+
+[[package]]
+name = "objc-foundation"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1add1b659e36c9607c7aab864a76c7a4c2760cd0cd2e120f3fb8b952c7e22bf9"
+dependencies = [
+ "block",
+ "objc",
+ "objc_id",
 ]
 
 [[package]]
@@ -2210,14 +2266,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.9.3"
+version = "1.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81bc1d4caf89fac26a70747fe603c130093b53c773888797a6329091246d651a"
+checksum = "697061221ea1b4a94a624f67d0ae2bfe4e22b8a17b6a192afb11046542cc8c47"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.3.6",
- "regex-syntax 0.7.4",
+ "regex-automata 0.3.8",
+ "regex-syntax 0.7.5",
 ]
 
 [[package]]
@@ -2231,13 +2287,13 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.3.6"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed1ceff11a1dddaee50c9dc8e4938bd106e9d89ae372f192311e7da498e3b69"
+checksum = "c2f401f4955220693b56f8ec66ee9c78abffd8d1c4f23dc41a23839eb88f0795"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.7.4",
+ "regex-syntax 0.7.5",
 ]
 
 [[package]]
@@ -2248,9 +2304,33 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
+checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
+
+[[package]]
+name = "rfd"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0149778bd99b6959285b0933288206090c50e2327f47a9c463bfdbf45c8823ea"
+dependencies = [
+ "block",
+ "dispatch",
+ "glib-sys",
+ "gobject-sys",
+ "gtk-sys",
+ "js-sys",
+ "lazy_static",
+ "log",
+ "objc",
+ "objc-foundation",
+ "objc_id",
+ "raw-window-handle",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows 0.37.0",
+]
 
 [[package]]
 name = "rustc-demangle"
@@ -2781,6 +2861,7 @@ dependencies = [
  "rand 0.8.5",
  "raw-window-handle",
  "regex",
+ "rfd",
  "semver",
  "serde",
  "serde_json",
@@ -2857,6 +2938,21 @@ dependencies = [
  "syn 1.0.109",
  "tauri-codegen",
  "tauri-utils",
+]
+
+[[package]]
+name = "tauri-plugin-log"
+version = "0.0.0"
+source = "git+https://github.com/tauri-apps/plugins-workspace?branch=v1#5b814f56e6368fdec46c4ddb04a07e0923ff995a"
+dependencies = [
+ "byte-unit",
+ "fern",
+ "log",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "time",
 ]
 
 [[package]]
@@ -3031,6 +3127,8 @@ checksum = "b0fdd63d58b18d663fbdf70e049f00a22c8e42be082203be7f26589213cd75ea"
 dependencies = [
  "deranged",
  "itoa 1.0.9",
+ "libc",
+ "num_threads",
  "serde",
  "time-core",
  "time-macros",
@@ -3262,6 +3360,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
+name = "utf8-width"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5190c9442dcdaf0ddd50f37420417d219ae5261bbf5db120d0f9bab996c9cba1"
+
+[[package]]
 name = "uuid"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3275,6 +3379,12 @@ name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+
+[[package]]
+name = "value-bag"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d92ccd67fb88503048c01b59152a04effd0782d035a83a6d256ce6085f08f4a3"
 
 [[package]]
 name = "version-compare"
@@ -3362,6 +3472,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c02dbc21516f9f1f04f187958890d7e6026df8d16540b7ad9492bc34a67cea03"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3389,6 +3511,16 @@ name = "wasm-bindgen-shared"
 version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
+
+[[package]]
+name = "web-sys"
+version = "0.3.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "webkit2gtk"
@@ -3508,6 +3640,19 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57b543186b344cc61c85b5aab0d2e3adf4e0f99bc076eff9aa5927bcc0b8a647"
+dependencies = [
+ "windows_aarch64_msvc 0.37.0",
+ "windows_i686_gnu 0.37.0",
+ "windows_i686_msvc 0.37.0",
+ "windows_x86_64_gnu 0.37.0",
+ "windows_x86_64_msvc 0.37.0",
+]
+
+[[package]]
+name = "windows"
 version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1c4bd0a50ac6020f65184721f758dba47bb9fbc2133df715ec74a237b26794a"
@@ -3614,6 +3759,12 @@ checksum = "b10d0c968ba7f6166195e13d593af609ec2e3d24f916f081690695cf5eaffb2f"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2623277cb2d1c216ba3b578c0f3cf9cdebeddb6e66b1b218bb33596ea7769c3a"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec7711666096bd4096ffa835238905bb33fb87267910e154b18b44eaabb340f2"
@@ -3629,6 +3780,12 @@ name = "windows_aarch64_msvc"
 version = "0.48.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "571d8d4e62f26d4932099a9efe89660e8bd5087775a2ab5cdd8b747b811f1058"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3925fd0b0b804730d44d4b6278c50f9699703ec49bcd628020f46f4ba07d9e1"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3650,6 +3807,12 @@ checksum = "2229ad223e178db5fbbc8bd8d3835e51e566b8474bfca58d2e6150c48bb723cd"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce907ac74fe331b524c1298683efbf598bb031bc84d5e274db2083696d07c57c"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bc7cbfe58828921e10a9f446fcaaf649204dcfe6c1ddd712c5eebae6bda1106"
@@ -3665,6 +3828,12 @@ name = "windows_i686_msvc"
 version = "0.48.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "600956e2d840c194eedfc5d18f8242bc2e17c7775b6684488af3a9fff6fe3287"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2babfba0828f2e6b32457d5341427dcbb577ceef556273229959ac23a10af33d"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3695,6 +3864,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.48.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f1a05a1ece9a7a0d5a7ccf30ba2c33e3a61a30e042ffd247567d1de1d94120d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4dd6dc7df2d84cf7b33822ed5b86318fb1781948e9663bacd047fc9dd52259d"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -437,30 +437,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-deque"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
-dependencies = [
- "cfg-if",
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae211234986c545741a7dc064309f67ee1e5ad243d0e48335adc0484d960bcc7"
-dependencies = [
- "autocfg",
- "cfg-if",
- "crossbeam-utils",
- "memoffset",
- "scopeguard",
-]
-
-[[package]]
 name = "crossbeam-utils"
 version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -788,12 +764,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fs_extra"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
-
-[[package]]
 name = "futf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -804,12 +774,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -847,6 +833,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-sink"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
+
+[[package]]
 name = "futures-task"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -858,9 +850,13 @@ version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
  "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
  "slab",
@@ -1618,17 +1614,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mio"
-version = "0.8.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
-dependencies = [
- "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "ndk"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1666,13 +1651,11 @@ checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
 name = "nmw"
 version = "0.0.0"
 dependencies = [
- "fs_extra",
+ "futures",
  "globwalk",
  "log",
- "rayon",
  "regex",
  "serde",
- "serde_json",
  "specta",
  "tauri",
  "tauri-build",
@@ -2214,28 +2197,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2ff9a1f06a88b01621b7ae906ef0211290d1c8a168a15542486a8f61c0833b9"
 
 [[package]]
-name = "rayon"
-version = "1.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d2df5196e37bcc87abebc0053e20787d73847bb33134a69841207dd0a47f03b"
-dependencies = [
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b8f95bd6966f5c87776639160a66bd8ab9895d9d4ab01ddba9fc60661aebe8d"
-dependencies = [
- "crossbeam-channel",
- "crossbeam-deque",
- "crossbeam-utils",
- "num_cpus",
-]
-
-[[package]]
 name = "redox_syscall"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2561,15 +2522,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "signal-hook-registry"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "simd-adler32"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2595,16 +2547,6 @@ name = "smallvec"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
-
-[[package]]
-name = "socket2"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2538b18701741680e0322a2302176d3253a35388e2e62f172f64f4f16605f877"
-dependencies = [
- "libc",
- "windows-sys 0.48.0",
-]
 
 [[package]]
 name = "soup2"
@@ -3172,26 +3114,8 @@ checksum = "17ed6077ed6cd6c74735e21f37eb16dc3935f96878b1fe961074089cc80893f9"
 dependencies = [
  "backtrace",
  "bytes",
- "libc",
- "mio",
  "num_cpus",
- "parking_lot",
  "pin-project-lite",
- "signal-hook-registry",
- "socket2",
- "tokio-macros",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "tokio-macros"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.28",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -15,17 +15,15 @@ tauri-build = { version = "1.4", features = [] }
 [dependencies]
 tauri = { version = "1.4", features = [ "dialog-all", "fs-read-file", "fs-read-dir", "shell-open"] }
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-fs_extra = "1.3.0"
-tokio = { version = "1.32.0", features = ["full"] }
+tokio = { version = "1.32.0", features = ["fs"] }
 thiserror = "1.0.47"
-rayon = "1.7.0"
 specta = "1.0.5"
 tauri-specta = { version = "1.0.2", features = ["typescript"] }
 regex = "1.9.5"
 tauri-plugin-log = { git = "https://github.com/tauri-apps/plugins-workspace", branch = "v1" }
 log = "0.4.20"
 globwalk = "0.8.1"
+futures = "0.3.28"
 
 [features]
 # this feature is used for production builds or when `devPath` points to the filesystem

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -13,16 +13,19 @@ edition = "2021"
 tauri-build = { version = "1.4", features = [] }
 
 [dependencies]
-tauri = { version = "1.4", features = [ "fs-read-file", "fs-read-dir", "shell-open"] }
+tauri = { version = "1.4", features = [ "dialog-all", "fs-read-file", "fs-read-dir", "shell-open"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-glob = "0.3.1"
 fs_extra = "1.3.0"
 tokio = { version = "1.32.0", features = ["full"] }
 thiserror = "1.0.47"
 rayon = "1.7.0"
 specta = "1.0.5"
 tauri-specta = { version = "1.0.2", features = ["typescript"] }
+regex = "1.9.5"
+tauri-plugin-log = { git = "https://github.com/tauri-apps/plugins-workspace", branch = "v1" }
+log = "0.4.20"
+globwalk = "0.8.1"
 
 [features]
 # this feature is used for production builds or when `devPath` points to the filesystem

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,3 +1,3 @@
 fn main() {
-  tauri_build::build()
+    tauri_build::build()
 }

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -1,5 +1,5 @@
-use serde::{Serialize, Serializer};
 use crate::FolderStat;
+use serde::{Serialize, Serializer};
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
@@ -13,8 +13,8 @@ pub enum Error {
 
 impl Serialize for Error {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-        where
-            S: Serializer,
+    where
+        S: Serializer,
     {
         serializer.serialize_str(self.to_string().as_ref())
     }

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -1,18 +1,20 @@
 use serde::{Serialize, Serializer};
+use crate::FolderStat;
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-    #[error("Failed to receive data from node_modules")]
-    ReceiveDirData(#[from] tokio::sync::oneshot::error::RecvError),
-
     #[error("Tokio can't readdir")]
     Io(#[from] std::io::Error),
+    #[error("Failed to forward folder statistics, internal channel is broken.")]
+    TrySendError(#[from] tokio::sync::mpsc::error::TrySendError<FolderStat>),
+    #[error("Node modules folder size too large to be represented in JavaScript.")]
+    TooLarge(#[from] std::num::TryFromIntError),
 }
 
 impl Serialize for Error {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
+        where
+            S: Serializer,
     {
         serializer.serialize_str(self.to_string().as_ref())
     }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -13,9 +13,9 @@ use std::path::Path;
 // use log::info;
 use error::Error;
 use futures::future::try_join_all;
-use util::FolderStat;
 use specta::collect_types;
 use tauri_specta::ts;
+use util::FolderStat;
 
 // use tauri_plugin_log::LogTarget;
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -25,7 +25,7 @@ async fn get_dir_data(pattern: &str) -> Result<Vec<FolderStat>, Error> {
     let dirs = util::get_dir_names(Path::new(pattern));
 
     let iter = dirs.into_iter().map(|path| async move {
-        let size = util::get_size(&path).await? as u32;
+        let size = u32::try_from(util::get_size(&path).await?)?;
         Ok(FolderStat { path, size }) as Result<FolderStat, Error>
     });
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,32 +1,46 @@
 // Prevents additional console window on Windows in release, DO NOT REMOVE!!
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
+/**
+ * @TODO
+ * figure out how to only show logs in dev without
+ * commenting out code before push.
+ */
 mod error;
 
+// use log::info;
 use error::Error;
-use fs_extra::dir::{self};
+use fs_extra::dir;
 use nmw::FolderStat;
 use rayon::prelude::*;
 use specta::collect_types;
 use tauri_specta::ts;
 use tokio::sync::oneshot;
 
+// use tauri_plugin_log::LogTarget;
+
 #[tauri::command]
 #[specta::specta]
 async fn get_dir_data(pattern: &str) -> Result<Vec<FolderStat>, Error> {
     let (tx, rx) = oneshot::channel::<Vec<FolderStat>>();
-    let files = nmw::get_file_names(pattern);
+    let dirs = nmw::get_dir_names(pattern);
     let mut result = vec![];
 
-    files
-        .into_par_iter()
+    // info!("get dir data starting");
+
+    dirs.into_par_iter()
         .map(|path: String| {
-            let size: u32 = dir::get_size(&path).expect("file size").try_into().unwrap();
+            let size: u32 = dir::get_size(&path)
+                .expect("file size")
+                .try_into()
+                .expect("not really sure");
             FolderStat { path, size }
         })
         .collect_into_vec(&mut result);
 
     tx.send(result).expect("File data did not reach receiver.");
+
+    // info!("finished measuring directories");
 
     Ok(nmw::order_list(rx.await?))
 }
@@ -36,6 +50,11 @@ fn main() {
     ts::export(collect_types![get_dir_data], "../src/commands.ts").unwrap();
 
     tauri::Builder::default()
+        // .plugin(
+        //     tauri_plugin_log::Builder::default()
+        //         .targets([LogTarget::LogDir, LogTarget::Stdout, LogTarget::Webview])
+        //         .build(),
+        // )
         .invoke_handler(tauri::generate_handler![get_dir_data])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/util.rs
+++ b/src-tauri/src/util.rs
@@ -1,18 +1,16 @@
-mod error;
-
 use globwalk::GlobWalkerBuilder;
 // use log::info;
 use regex::Regex;
-use std::path::Path;
-
+use std::path::{Path, PathBuf};
 use core::future::Future;
 use core::pin::Pin;
 use serde::Serialize;
 use specta::Type;
+use crate::error::Error;
 
 #[derive(Serialize, Type, Debug)]
 pub struct FolderStat {
-    pub path: String,
+    pub path: PathBuf,
     pub size: u32,
 }
 
@@ -23,25 +21,25 @@ pub fn order_list(mut list: Vec<FolderStat>) -> Vec<FolderStat> {
     list
 }
 
-pub fn get_size<'a>(path: &'a Path) -> Pin<Box<dyn Future<Output = u64> + 'a>> {
+pub fn get_size<'a>(path: &'a Path) -> Pin<Box<dyn Future<Output = Result<u64, Error>> + 'a + Send>> {
     Box::pin(async move {
         // Using `fs::symlink_metadata` since we don't want to follow symlinks,
         // as we're calculating the exact size of the requested path itself.
-        let path_metadata = tokio::fs::symlink_metadata(&path).await.unwrap();
+        let path_metadata = tokio::fs::symlink_metadata(&path).await?;
         let mut size_in_bytes = 0;
 
         if path_metadata.is_dir() {
-            let mut read_dir = tokio::fs::read_dir(&path).await.unwrap();
+            let mut read_dir = tokio::fs::read_dir(&path).await?;
 
-            while let Some(entry) = read_dir.next_entry().await.unwrap() {
+            while let Some(entry) = read_dir.next_entry().await? {
                 // `DirEntry::metadata` does not follow symlinks (unlike `fs::metadata`), so in the
                 // case of symlinks, this is the size of the symlink itself, not its target.
-                let entry_metadata = entry.metadata().await.unwrap();
+                let entry_metadata = entry.metadata().await?;
 
                 if entry_metadata.is_dir() {
                     // The size of the directory entry itself will be counted inside the `get_size()` call,
                     // so we intentionally don't also add `entry_metadata.len()` to the total here.
-                    size_in_bytes += get_size(&entry.path()).await;
+                    size_in_bytes += get_size(&entry.path()).await?;
                 } else {
                     size_in_bytes += entry_metadata.len();
                 }
@@ -49,12 +47,12 @@ pub fn get_size<'a>(path: &'a Path) -> Pin<Box<dyn Future<Output = u64> + 'a>> {
         } else {
             size_in_bytes = path_metadata.len();
         }
-        size_in_bytes
+        Ok(size_in_bytes)
     })
 }
 
-pub fn get_dir_names(path: &str) -> Vec<String> {
-    let mut filenames: Vec<String> = Vec::new();
+pub fn get_dir_names(path: &Path) -> Vec<PathBuf> {
+    let mut filenames = Vec::new();
 
     let walker = GlobWalkerBuilder::from_patterns(path, &["**/node_modules", "**/![.pnpm]/*"])
         .max_depth(6)
@@ -83,7 +81,7 @@ pub fn get_dir_names(path: &str) -> Vec<String> {
         }
 
         if should_scan {
-            filenames.push(path_string)
+            filenames.push(file.path().to_path_buf())
         }
     }
 

--- a/src-tauri/src/util.rs
+++ b/src-tauri/src/util.rs
@@ -1,12 +1,12 @@
 use globwalk::GlobWalkerBuilder;
 // use log::info;
-use regex::Regex;
-use std::path::{Path, PathBuf};
+use crate::error::Error;
 use core::future::Future;
 use core::pin::Pin;
+use regex::Regex;
 use serde::Serialize;
 use specta::Type;
-use crate::error::Error;
+use std::path::{Path, PathBuf};
 
 #[derive(Serialize, Type, Debug)]
 pub struct FolderStat {
@@ -21,7 +21,9 @@ pub fn order_list(mut list: Vec<FolderStat>) -> Vec<FolderStat> {
     list
 }
 
-pub fn get_size<'a>(path: &'a Path) -> Pin<Box<dyn Future<Output = Result<u64, Error>> + 'a + Send>> {
+pub fn get_size<'a>(
+    path: &'a Path,
+) -> Pin<Box<dyn Future<Output = Result<u64, Error>> + 'a + Send>> {
     Box::pin(async move {
         // Using `fs::symlink_metadata` since we don't want to follow symlinks,
         // as we're calculating the exact size of the requested path itself.

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -17,6 +17,9 @@
         "all": false,
         "open": true
       },
+      "dialog": {
+        "all": true
+      },
       "fs": {
         "scope": ["$DOCUMENT/*"],
         "readDir": true,


### PR DESCRIPTION
This refactors the `get_dir_data` command to improve error handling and actually use the async `get_size` function. In the process a number of dependencies aren't needed anymore (such as rayon) and can be removed.

The improved error handling mostly comes from the `try_join_all` function which takes in an iterator of `Future<Output = Result<T>>`, awaiting all futures (that are reading the directory size from disk) concurrently and then collecting the results into a `Vec`, if any of these futures returns an error then `try_join_all` will bail and discard the other futures.

 Other changes:
 - removed the `lib.rs` file and named it `util.rs, unsure if having both a binary and library in the same crate was your intention, feel free to revert this if it was.
 - Use `Path`/`PathBuf` instead of `String` in places where arguments are meant to be file paths.