### PR TITLE
fix: Not working on Windows due to path backslash

### DIFF
--- a/src/lib/get-dir-name.ts
+++ b/src/lib/get-dir-name.ts
@@ -1,6 +1,7 @@
 const REGEX = /^(.*\/)([^/]+)\/node_modules$/;
 
 export function getDirName(path: string) {
+  path = path.replace(/\\/g, '/');
   const match = path.match(REGEX);
 
   if (match) {


### PR DESCRIPTION
I just tried to play with it on Windows 10 and didn't work.  Then I found out the culprit was that the path in Windows are \ and not / as expected. So this simply replace all backslash with slash. Now it's working.

For reference this was the issue, successful scan but no result printed:
![image](https://github.com/atilafassina/pulsar/assets/61759797/b0dd1313-ac86-4d17-b87c-8dc34d041e4b)

I believe there's no need to modify in Rust as it utilizes `std::path`. 