### PR TITLE
Fix: Only remove entry if deletion is confirmed

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,8 +30,10 @@
   "devDependencies": {
     "@tauri-apps/cli": "2.0.0-beta.20",
     "internal-ip": "^7.0.0",
+    "prettier": "^3.3.3",
     "typescript": "^5.2.2",
     "vite": "^4.5.0",
     "vite-plugin-solid": "^2.7.2"
-  }
+  },
+  "prettier": {}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,6 +51,9 @@ importers:
       internal-ip:
         specifier: ^7.0.0
         version: 7.0.0
+      prettier:
+        specifier: ^3.3.3
+        version: 3.3.3
       typescript:
         specifier: ^5.2.2
         version: 5.4.5
@@ -1005,6 +1008,11 @@ packages:
   postcss@8.4.38:
     resolution: {integrity: sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==}
     engines: {node: ^10 || ^12 || >=14}
+
+  prettier@3.3.3:
+    resolution: {integrity: sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==}
+    engines: {node: '>=14'}
+    hasBin: true
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -2106,6 +2114,8 @@ snapshots:
       nanoid: 3.3.7
       picocolors: 1.0.1
       source-map-js: 1.2.0
+
+  prettier@3.3.3: {}
 
   queue-microtask@1.2.3: {}
 

--- a/src-tauri/src/util.rs
+++ b/src-tauri/src/util.rs
@@ -55,6 +55,7 @@ pub fn get_size<'a>(
 
 pub fn get_dir_names(path: &Path) -> Vec<PathBuf> {
     let mut filenames = Vec::new();
+    let node_modules_regex = Regex::new(r"node_modules").unwrap();
 
     let walker = GlobWalkerBuilder::from_patterns(path, &["**/node_modules", "**/![.pnpm]/*"])
         .max_depth(6)
@@ -66,7 +67,6 @@ pub fn get_dir_names(path: &Path) -> Vec<PathBuf> {
 
     for file in walker {
         let path_string = file.path().display().to_string();
-        let node_modules_regex = Regex::new(r"node_modules").unwrap();
 
         let mut count = 0;
         let mut start = 0;

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -44,8 +44,8 @@
         "fullscreen": false,
         "resizable": true,
         "title": "pulsar",
-        "width": 800,
-        "height": 600
+        "minWidth": 1000,
+        "minHeight": 800
       }
     ]
   }

--- a/src/components/results-table.tsx
+++ b/src/components/results-table.tsx
@@ -23,37 +23,38 @@ function deleteNodeModules(path: string) {
     const fileExists = await exists(path);
 
     if (fileExists) {
-      const shouldDelete = await confirm(
-        `${path} will be DELETED.
-      
-      Are you sure?
-      `,
-        {
-          kind: "warning",
-          title: "NON-REVERSIBLE ACTION",
-          okLabel: "DELETE",
-        }
-      );
-
-      if (shouldDelete) {
-        console.warn(":: deleting ::");
-        const rm = await remove(`${path}/node_modules`, { recursive: true });
-        console.log(rm);
-        return true;
-      }
+      console.warn(":: deleting ::");
+      await remove(`${path}/node_modules`, { recursive: true });
     }
 
-    return false;
+    return true;
   };
 }
 
 function TableRow(props: TRprops) {
   const [shouldDelete, setDelete] = createSignal(false);
 
-  const [data, { mutate }] = createResource(
+  const [data] = createResource(
     shouldDelete,
-    deleteNodeModules(props.directoryPrefix + props.directory)
+    deleteNodeModules(props.directoryPrefix + props.directory),
   );
+
+  async function confirmDelete() {
+    const shouldDelete = await confirm(
+      `${props.directoryPrefix + props.directory} will be DELETED.
+    
+    Are you sure?
+    `,
+      {
+        kind: "warning",
+        title: "NON-REVERSIBLE ACTION",
+        okLabel: "DELETE",
+      },
+    );
+
+    setDelete(shouldDelete);
+  }
+
   return (
     <Show when={!data()}>
       <tr
@@ -82,9 +83,8 @@ function TableRow(props: TRprops) {
             <li>
               <button
                 type="button"
-                onClick={() => {
-                  mutate(true);
-                  setDelete(true);
+                onClick={async () => {
+                  await confirmDelete();
                 }}
               >
                 <Trashbin />
@@ -98,8 +98,6 @@ function TableRow(props: TRprops) {
 }
 
 export default function ResultsTable(props: ListProps) {
-  const [selected, setSelected] = createSignal([]);
-
   return (
     <table class="w-full text-center">
       <thead class="sticky top-0 backdrop-blur-xl">


### PR DESCRIPTION
This fixes the issue where the entry goes temporarily when the confirmation box is shown. This PR prevents that and only removes the entry if the deletion is set to `true` by the user.

This also add a `minWidth` and `minHeight` to make it look better for general folder names.